### PR TITLE
feat: Continue Python environment setup even without API keys

### DIFF
--- a/run-server.sh
+++ b/run-server.sh
@@ -1059,8 +1059,8 @@ migrate_env_file() {
     echo "  (Backup saved as .env.backup_*)"
 }
 
-# Validate API keys
-validate_api_keys() {
+# Check API keys and warn if missing (non-blocking)
+check_api_keys() {
     local has_key=false
     local api_keys=(
         "GEMINI_API_KEY:your_gemini_api_key_here"
@@ -1088,22 +1088,24 @@ validate_api_keys() {
     fi
     
     if [[ "$has_key" == false ]]; then
-        print_error "No API keys found in .env!"
-        echo "" >&2
-        echo "Please edit .env and add at least one API key:" >&2
-        echo "  GEMINI_API_KEY=your-actual-key" >&2
-        echo "  OPENAI_API_KEY=your-actual-key" >&2
-        echo "  XAI_API_KEY=your-actual-key" >&2
-        echo "  DIAL_API_KEY=your-actual-key" >&2
-        echo "  OPENROUTER_API_KEY=your-actual-key" >&2
-        echo "" >&2
-        print_info "After adding your API keys, run ./run-server.sh again" >&2
-        echo "" >&2
-        return 1
+        print_warning "No API keys found in .env!"
+        echo ""
+        echo "The Python development environment will be set up, but you won't be able to use the MCP server until you add API keys."
+        echo ""
+        echo "To add API keys, edit .env and add at least one:"
+        echo "  GEMINI_API_KEY=your-actual-key"
+        echo "  OPENAI_API_KEY=your-actual-key"
+        echo "  XAI_API_KEY=your-actual-key"
+        echo "  DIAL_API_KEY=your-actual-key"
+        echo "  OPENROUTER_API_KEY=your-actual-key"
+        echo ""
+        print_info "You can continue with development setup and add API keys later."
+        echo ""
     fi
     
-    return 0
+    return 0  # Always return success to continue setup
 }
+
 
 # ----------------------------------------------------------------------------
 # Claude Integration Functions
@@ -1623,8 +1625,8 @@ main() {
         set +a
     fi
     
-    # Step 4: Validate API keys
-    validate_api_keys || exit 1
+    # Step 4: Check API keys (non-blocking - just warn if missing)
+    check_api_keys
     
     # Step 5: Setup Python environment (uv-first approach)
     local python_cmd
@@ -1652,7 +1654,7 @@ main() {
     echo "Logs will be written to: $script_dir/$LOG_DIR/$LOG_FILE"
     echo ""
     
-    # Step 11: Handle command line arguments
+    # Step 12: Handle command line arguments
     if [[ "$arg" == "-f" ]] || [[ "$arg" == "--follow" ]]; then
         follow_logs
     else


### PR DESCRIPTION
Modified run-server.sh to allow developers to set up the Python development environment without having API keys configured. This enables:

- Developers to clone and immediately start working on the codebase
- Running tests that don't require API calls
- Browsing and understanding the code structure
- Adding API keys later when ready to test MCP server functionality

Changes:
- Added new check_api_keys() function that warns but doesn't exit
- Changed print_error to print_warning for missing keys
- Updated main() to use check_api_keys instead of validate_api_keys || exit 1

The script now shows a warning when API keys are missing but continues with the full Python environment setup, dependencies installation, and Claude configuration.